### PR TITLE
Fixed infinite loop when an incorrect multiplicative key is used.

### DIFF
--- a/js/ciphers/affine.js
+++ b/js/ciphers/affine.js
@@ -1,4 +1,3 @@
-
 // Affine Cipher
 
 // This code was written by Tyler Akins and is placed in the public domain.
@@ -15,42 +14,45 @@
 // key = the key to alter the alphabet
 // alphabet = The alphabet to use if not A-Z
 //ALPHABET is out of order because Christensen says a starts at 1
-function affine(mult, inc, text, isDecrypt = "encrypt", alphabet = 'ZABCDEFGHIJKLMNOPQRSTUVWXY')
-{
+function affine(mult, inc, text, isDecrypt = "encrypt", alphabet = 'ZABCDEFGHIJKLMNOPQRSTUVWXY') {
     var output = "";
-    
-    if (typeof(alphabet) != 'string')
-       alphabet = 'ZABCDEFGHIJKLMNOPQRSTUVWXY';
-    
+
+    if (typeof (alphabet) != 'string')
+        alphabet = 'ZABCDEFGHIJKLMNOPQRSTUVWXY';
+
     mult = mult * 1;
     inc = inc * 1;
-    if (isDecrypt == "decrypt") {
-       var i = 1;
-       while ((mult * i) % 26 != 1) {
-           i += 2;
-       }
-       mult = i;
-       inc = mult * (alphabet.length - inc) % alphabet.length;
+
+    // Popup to warn of incorrect keys and to avoid infinite loops
+    if (mult % 2 == 0 || mult % 13 == 0) {
+        window.alert("The multiplicative key cannot be zero, an even number, or a multiple of 13 when decoding!");
+        mult = 1;
+        inc = 0;
+        isDecrypt = 0;
     }
-    
-    key =  alphabet;
-    
-    for (var i = 0; i < text.length; i++)
-    {
-       var b = text.charAt(i);
-       var idx;
-       if ((idx = alphabet.indexOf(b)) >= 0)
-       {
+    if (isDecrypt == "decrypt") {
+        var i = 1;
+        while ((mult * i) % 26 != 1) {
+            i += 2;
+        }
+        mult = i;
+        inc = mult * (alphabet.length - inc) % alphabet.length;
+    }
+
+    key = alphabet;
+
+    for (var i = 0; i < text.length; i++) {
+        var b = text.charAt(i);
+        var idx;
+        if ((idx = alphabet.indexOf(b)) >= 0) {
             idx = (mult * idx + inc) % alphabet.length;
             b = key.charAt(idx);
-       }
-       else if ((idx = alphabet.indexOf(b.toUpperCase())) >= 0)
-       {
+        } else if ((idx = alphabet.indexOf(b.toUpperCase())) >= 0) {
             idx = (mult * idx + inc) % alphabet.length;
             b = key.charAt(idx);
-       }
-       output += b;
+        }
+        output += b;
     }
     return output;
- }
+}
  

--- a/js/ciphers/multiplicative.js
+++ b/js/ciphers/multiplicative.js
@@ -14,6 +14,8 @@
 // key = the key to alter the alphabet
 // alphabet = The alphabet to use if not A-Z
 //ALPHABET is out of order because Christiansen says a starts at 1
+
+//This functioned is unused
 function multiplicative(mult, text, alphabet = 'ZABCDEFGHIJKLMNOPQRSTUVWXY', isDecrypt = "decrypt")
 {
     var output = "";


### PR DESCRIPTION
Added code to affine.js to avoid infinite loops when an incorrect multiplicative key is given, informing the user.
Added comment to multiplicative.js to inform it is unused.